### PR TITLE
Chore: downgrade spring boot to 3.5.9

### DIFF
--- a/backend/devstagram/build.gradle.kts
+++ b/backend/devstagram/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	java
-	id("org.springframework.boot") version "4.0.1"
+	id("org.springframework.boot") version "3.5.9"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("com.diffplug.spotless") version "8.1.0"
 	id("checkstyle")
@@ -60,14 +60,22 @@ checkstyle {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springframework.boot:spring-boot-starter-webmvc")
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+
+	runtimeOnly("com.h2database:h2")
+
 	compileOnly("org.projectlombok:lombok")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
-	runtimeOnly("com.mysql:mysql-connector-j")
 	annotationProcessor("org.projectlombok:lombok")
-	testImplementation("org.springframework.boot:spring-boot-starter-security-test")
-	testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+	developmentOnly("org.springframework.boot:spring-boot-devtools")
+
+	// runtimeOnly("com.mysql:mysql-connector-j")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testRuntimeOnly("com.h2database:h2")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #16

## 🛠 작업 내역

- Spring Boot 버전을 4.0.1에서 3.5.9로 다운그레이드했습니다.
- 테스트 의존성을 정리해 Boot 3.5 환경에 맞게 수정했습니다.
- 팀 개발 환경의 호환성 이슈를 줄이기 위해 기본 실행 환경을 안정화했습니다.

## ✅ 체크리스트

- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션을 준수하는가?
- [x] PR과 관련 없는 변경사항이 없는가?
- [x] Test가 완료되었는가?