### PR TITLE
Fix: media upload cors limit

### DIFF
--- a/backend/devstagram/src/main/java/com/devstagram/domain/dm/dto/DmMessageResponse.java
+++ b/backend/devstagram/src/main/java/com/devstagram/domain/dm/dto/DmMessageResponse.java
@@ -1,7 +1,5 @@
 package com.devstagram.domain.dm.dto;
 
-import java.time.LocalDateTime;
-
 import com.devstagram.domain.dm.entity.MessageType;
 
 public record DmMessageResponse(
@@ -10,6 +8,6 @@ public record DmMessageResponse(
         String content,
         String thumbnail,
         boolean valid,
-        LocalDateTime createdAt,
+        String createdAt,
         Long senderId // 메시지 로드 시 나/상대방 구분을 위해 추가
         ) {}

--- a/backend/devstagram/src/main/java/com/devstagram/domain/dm/service/DmService.java
+++ b/backend/devstagram/src/main/java/com/devstagram/domain/dm/service/DmService.java
@@ -572,7 +572,6 @@ public class DmService {
 
     private String toKstString(LocalDateTime dateTime) {
         if (dateTime == null) return null;
-        return dateTime.atZone(ZoneId.of("Asia/Seoul"))
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        return dateTime.atZone(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 }

--- a/backend/devstagram/src/main/java/com/devstagram/domain/dm/service/DmService.java
+++ b/backend/devstagram/src/main/java/com/devstagram/domain/dm/service/DmService.java
@@ -1,5 +1,8 @@
 package com.devstagram.domain.dm.service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +93,7 @@ public class DmService {
                         dm.getContent(),
                         dm.getThumbnailUrl(),
                         dm.isValid(),
-                        dm.getCreatedAt(),
+                        toKstString(dm.getCreatedAt()),
                         dm.getSender().getId() // 누가 보냈는지까지 같이 담아서
                         ))
                 .collect(Collectors.toList());
@@ -256,7 +259,7 @@ public class DmService {
                                 last.getContent(),
                                 last.getThumbnailUrl(),
                                 last.isValid(),
-                                last.getCreatedAt(),
+                                toKstString(last.getCreatedAt()),
                                 last.getSender().getId());
                     }
 
@@ -366,7 +369,7 @@ public class DmService {
                 saved.getContent(),
                 saved.getThumbnailUrl(),
                 saved.isValid(),
-                saved.getCreatedAt(),
+                toKstString(saved.getCreatedAt()),
                 saved.getSender().getId());
     }
 
@@ -565,5 +568,11 @@ public class DmService {
         return dmRoomUserRepository
                 .findByDmRoom_IdAndUser_Id(roomId, userId)
                 .orElseThrow(() -> new ServiceException("404-F-1", "참여 중인 채팅방이 아닙니다."));
+    }
+
+    private String toKstString(LocalDateTime dateTime) {
+        if (dateTime == null) return null;
+        return dateTime.atZone(ZoneId.of("Asia/Seoul"))
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 }

--- a/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmControllerAuthHeaderTest.java
+++ b/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmControllerAuthHeaderTest.java
@@ -162,7 +162,7 @@ class DmControllerAuthHeaderTest {
                         "나갔습니다.",
                         null,
                         true,
-                        java.time.LocalDateTime.now(),
+                        "2026-04-09T07:13:39+09:00",
                         1L);
         when(dmService.leaveGroupRoom(1L, 100L)).thenReturn(messageResponse);
 

--- a/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmWebSocketControllerTest.java
+++ b/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmWebSocketControllerTest.java
@@ -66,7 +66,7 @@ class DmWebSocketControllerTest {
 
         DmSendMessageRequest req = new DmSendMessageRequest(MessageType.TEXT, "hello", null);
         DmMessageResponse saved =
-                new DmMessageResponse(10L, MessageType.TEXT, "hello", null, true, LocalDateTime.now(), 1L);
+                new DmMessageResponse(10L, MessageType.TEXT, "hello", null, true, "2026-04-09T07:13:39+09:00", 1L);
         when(dmService.sendMessage(1L, 1L, req)).thenReturn(saved);
 
         controller.message(stompSendMessageWithUser(securityUser), 1L, req);
@@ -87,7 +87,7 @@ class DmWebSocketControllerTest {
 
         DmSendMessageRequest req = new DmSendMessageRequest(MessageType.TEXT, "hello", null);
         DmMessageResponse saved =
-                new DmMessageResponse(10L, MessageType.TEXT, "hello", null, true, LocalDateTime.now(), 1L);
+                new DmMessageResponse(10L, MessageType.TEXT, "hello", null, true, "2026-04-09T07:13:39+09:00", 1L);
         when(dmService.sendMessage(1L, 1L, req)).thenReturn(saved);
 
         controller.message(null, 1L, req);

--- a/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmWebSocketControllerTest.java
+++ b/backend/devstagram/src/test/java/com/devstagram/domain/dm/controller/DmWebSocketControllerTest.java
@@ -3,7 +3,6 @@ package com.devstagram.domain.dm.controller;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -7,6 +7,8 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    client_max_body_size 50M;
+
     # 도커 내부 DNS 서버 주소 설정
     resolver 127.0.0.11;
 


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #
## 🛠 작업 내역

- S3 CORS 설정을 추가해 게시글 수정 시 이미지 추가가 가능하도록 수정했습니다.
- nginx 업로드 용량 제한을 늘려 1MB 초과 이미지 업로드 시 발생하던 `413 Request Entity Too Large` 문제를 해결했습니다.
- DM 메시지 응답의 `createdAt`을 타임존 정보가 포함된 문자열로 내려주도록 변경했습니다.
- 관련 테스트 코드에서 변경된 `DmMessageResponse` 스펙에 맞게 수정했습니다.

## 상세 변경 사항

### 1. 미디어 업로드 관련
- 게시글/스토리 작성 및 수정 과정에서 이미지 업로드 시 실패하던 문제를 확인했습니다.
- 브라우저 콘솔 및 네트워크 확인 결과:
  - 초기에는 S3 CORS 문제가 있었습니다.
  - 이후 `413 Request Entity Too Large`를 확인했습니다.

#### 대응
- S3 버킷 CORS 설정을 추가했습니다.
- nginx에 `client_max_body_size 50M`을 적용했습니다.

### 2. DM 시간 응답 관련
- 기존에는 `DmMessageResponse.createdAt`이 `LocalDateTime`이라 타임존 정보 없이 내려가고 있었습니다.
- 이로 인해 프론트에서 한국 시간 기준으로 일관되게 처리하기 어려운 문제가 있었습니다.

#### 대응
- `DmMessageResponse.createdAt` 타입을 `String`으로 변경했습니다.
- `DmService`에서 `createdAt`을 `ISO_OFFSET_DATE_TIME` 형식의 KST 문자열로 변환 후 응답하도록 수정했습니다.
- 메시지 목록 조회 / 마지막 메시지 조회 / 메시지 전송 응답에 동일하게 적용했습니다.

## 변경 파일
- `DmMessageResponse`
- `DmService`
- DM 관련 테스트 2건
- nginx 설정 파일
- S3 CORS 설정

## 테스트
- DM 관련 테스트 수정 후 통과 확인
- 전체 테스트 통과 확인
- 로컬 환경에서 1MB 초과 파일 업로드 동작 확인00

## 기대 효과
- 게시글/스토리 작성 및 수정 시 이미지 업로드 안정성이 개선됩니다.
- 운영 환경에서 업로드 용량 제한으로 인한 413 에러 발생 가능성을 줄일 수 있습니다.
- DM 시간 표시를 한국 시간 기준으로 일관되게 처리할 수 있습니다.

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?
